### PR TITLE
Make channel's and client's listeners null-safe

### DIFF
--- a/lib/src/agora_rtm_channel.dart
+++ b/lib/src/agora_rtm_channel.dart
@@ -56,26 +56,26 @@ class AgoraRtmChannel {
       case 'onMessageReceived':
         AgoraRtmMessage message = AgoraRtmMessage.fromJson(map['message']);
         AgoraRtmMember member = AgoraRtmMember.fromJson(map);
-        this?.onMessageReceived(message, member);
+        this?.onMessageReceived?.call(message, member);
         break;
       case 'onMemberJoined':
         AgoraRtmMember member = AgoraRtmMember.fromJson(map);
-        this?.onMemberJoined(member);
+        this?.onMemberJoined?.call(member);
         break;
       case 'onMemberLeft':
         AgoraRtmMember member = AgoraRtmMember.fromJson(map);
-        this?.onMemberLeft(member);
+        this?.onMemberLeft?.call(member);
         break;
       case 'onAttributesUpdated':
         List<Map<dynamic, dynamic>> attributes =
             List<Map<dynamic, dynamic>>.from(map['attributes']);
-        this?.onAttributesUpdated(attributes
+        this?.onAttributesUpdated?.call(attributes
             .map((attr) => AgoraRtmChannelAttribute.fromJson(attr))
             .toList());
         break;
       case 'onMemberCountUpdated':
         int count = map['count'];
-        this?.onMemberCountUpdated(count);
+        this?.onMemberCountUpdated?.call(count);
         break;
     }
   }

--- a/lib/src/agora_rtm_client.dart
+++ b/lib/src/agora_rtm_client.dart
@@ -110,55 +110,55 @@ class AgoraRtmClient {
       case 'onConnectionStateChanged':
         int state = map['state'];
         int reason = map['reason'];
-        this?.onConnectionStateChanged(state, reason);
+        this?.onConnectionStateChanged?.call(state, reason);
         break;
       case 'onMessageReceived':
         AgoraRtmMessage message = AgoraRtmMessage.fromJson(map["message"]);
         String peerId = map["peerId"];
-        this?.onMessageReceived(message, peerId);
+        this?.onMessageReceived?.call(message, peerId);
         break;
       case 'onTokenExpired':
-        this?.onTokenExpired();
+        this?.onTokenExpired?.call();
         break;
       case 'onLocalInvitationReceivedByPeer':
-        this?.onLocalInvitationReceivedByPeer(
+        this?.onLocalInvitationReceivedByPeer?.call(
             AgoraRtmLocalInvitation.fromJson(map['localInvitation']));
         break;
       case 'onLocalInvitationAccepted':
-        this?.onLocalInvitationAccepted(
+        this?.onLocalInvitationAccepted?.call(
             AgoraRtmLocalInvitation.fromJson(map['localInvitation']));
         break;
       case 'onLocalInvitationRefused':
-        this?.onLocalInvitationRefused(
+        this?.onLocalInvitationRefused?.call(
             AgoraRtmLocalInvitation.fromJson(map['localInvitation']));
         break;
       case 'onLocalInvitationCanceled':
-        this?.onLocalInvitationCanceled(
+        this?.onLocalInvitationCanceled?.call(
             AgoraRtmLocalInvitation.fromJson(map['localInvitation']));
         break;
       case 'onLocalInvitationFailure':
-        this?.onLocalInvitationFailure(
+        this?.onLocalInvitationFailure?.call(
             AgoraRtmLocalInvitation.fromJson(map['localInvitation']),
             map['errorCode']);
         break;
       case 'onRemoteInvitationReceivedByPeer':
-        this?.onRemoteInvitationReceivedByPeer(
+        this?.onRemoteInvitationReceivedByPeer?.call(
             AgoraRtmRemoteInvitation.fromJson(map['remoteInvitation']));
         break;
       case 'onRemoteInvitationAccepted':
-        this?.onRemoteInvitationAccepted(
+        this?.onRemoteInvitationAccepted?.call(
             AgoraRtmRemoteInvitation.fromJson(map['remoteInvitation']));
         break;
       case 'onRemoteInvitationRefused':
-        this?.onRemoteInvitationRefused(
+        this?.onRemoteInvitationRefused?.call(
             AgoraRtmRemoteInvitation.fromJson(map['remoteInvitation']));
         break;
       case 'onRemoteInvitationCanceled':
-        this?.onRemoteInvitationCanceled(
+        this?.onRemoteInvitationCanceled?.call(
             AgoraRtmRemoteInvitation.fromJson(map['remoteInvitation']));
         break;
       case 'onRemoteInvitationFailure':
-        this?.onRemoteInvitationFailure(
+        this?.onRemoteInvitationFailure?.call(
             AgoraRtmRemoteInvitation.fromJson(map['remoteInvitation']),
             map['errorCode']);
         break;


### PR DESCRIPTION
With the current approach, whenever an event occurs in channel or client that triggers a callback  invocation (i.e: `channel.onMemberJoined`), if that callback is not set, a null pointer is thrown.

This pull request aims to add null-safety to all listeners