### PR TITLE
Fixed ios build issue

### DIFF
--- a/ios/agora_rtm.podspec
+++ b/ios/agora_rtm.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.version          = project.version
   s.summary          = 'A new flutter plugin project.'
   s.description      = project.description
-  s.homepage         = project.docs
+  s.homepage         = project.homepage
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'Agora' => 'developer@agora.io' }
   s.source           = { :path => '.' }


### PR DESCRIPTION
Hi guys, we are facing the issue below when we tried to build the app. 

```
[!] The `agora_rtm` pod failed to validate due to 1 error:
        - ERROR | attributes: Missing required attribute `homepage`.
        - WARN  | license: Missing license type.
        - WARN  | [iOS] keys: Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.
```

This PR fixed the issue. Could you check  and deploy a new version of the lib on Flutter Packages repository ASAP? 

Thanks.
