### PR TITLE
chore: add finalize-only flow for 1.6.4 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: boolean
         default: true
+      finalize-only:
+        description: 'Skip release preparation and pub.dev publishing; only finalize an existing release'
+        required: false
+        type: boolean
+        default: false
       force-publish-to-pub:
         description: 'Force publish to pub.dev regardless of version format'
         required: false
@@ -31,6 +36,11 @@ on:
         required: false
         type: boolean
         default: true
+      finalize-only:
+        description: 'Skip release preparation and pub.dev publishing; only finalize an existing release'
+        required: false
+        type: boolean
+        default: false
       force-publish-to-pub:
         description: 'Force publish to pub.dev regardless of version format'
         required: false
@@ -109,17 +119,28 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             DRY_RUN="${{ github.event.inputs.dry-run }}"
             FORCE_PUBLISH="${{ github.event.inputs.force-publish-to-pub }}"
+            FINALIZE_ONLY="${{ github.event.inputs.finalize-only }}"
           elif [ "${{ github.event_name }}" = "workflow_call" ]; then
             DRY_RUN="${{ inputs.dry-run }}"
             FORCE_PUBLISH="${{ inputs.force-publish-to-pub }}"
+            FINALIZE_ONLY="${{ inputs.finalize-only }}"
           else
             DRY_RUN="false" # PR triggers are always production mode
             FORCE_PUBLISH="false"
+            FINALIZE_ONLY="false"
           fi
 
           echo "Dry-run mode: $DRY_RUN"
           echo "Force publish mode: $FORCE_PUBLISH"
+          echo "Finalize-only mode: $FINALIZE_ONLY"
+
+          if [ "$FINALIZE_ONLY" = "true" ] && [ "$DRY_RUN" != "false" ]; then
+            echo "Finalize-only mode requires dry-run=false." >&2
+            exit 1
+          fi
+
           echo "dry-run=$DRY_RUN" >> $GITHUB_OUTPUT
+          echo "finalize-only=$FINALIZE_ONLY" >> $GITHUB_OUTPUT
 
           # Get version from inputs (for workflow_dispatch and workflow_call) or pubspec.yaml (for PR)
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -167,6 +188,11 @@ jobs:
             fi
           fi
 
+          if [ "$FINALIZE_ONLY" = "true" ] && [ "$RELEASE_TYPE" != "standard" ]; then
+            echo "Finalize-only mode only supports standard releases." >&2
+            exit 1
+          fi
+
           echo "Release version: $RELEASE_VERSION"
           echo "Release type: $RELEASE_TYPE"
           echo "Is prerelease: $IS_PRERELEASE"
@@ -176,6 +202,7 @@ jobs:
           echo "is_prerelease=$IS_PRERELEASE" >> $GITHUB_OUTPUT
 
       - name: Install release tools
+        if: ${{ steps.version_check.outputs.finalize-only != 'true' }}
         run: |
           npm install -g release-it
           npm install -g release-it/bumper
@@ -187,7 +214,8 @@ jobs:
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
       - name: Prepare release files (triggered by manual/callable)
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
+        if: ${{ steps.version_check.outputs.finalize-only != 'true' &&
+                (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') }}
         run: |
           set -eo pipefail
 
@@ -203,7 +231,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Archive changelog for pub.dev
-        if: ${{ steps.version_check.outputs.release_type == 'standard' }}
+        if: ${{ steps.version_check.outputs.release_type == 'standard' &&
+                steps.version_check.outputs.finalize-only != 'true' }}
         run: |
           bash scripts/archive_changelog.sh
 
@@ -223,6 +252,7 @@ jobs:
           fi
 
       - name: Commit prepared release files locally
+        if: ${{ steps.version_check.outputs.finalize-only != 'true' }}
         run: |
           set -eo pipefail
 
@@ -239,21 +269,26 @@ jobs:
           fi
 
       - name: Setup Flutter for pub publish
-        if: ${{ steps.version_check.outputs.release_type == 'standard' }}
+        if: ${{ steps.version_check.outputs.release_type == 'standard' &&
+                steps.version_check.outputs.finalize-only != 'true' }}
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
           cache: true
 
       - name: Publish to pub.dev (dry-run check)
-        if: ${{ steps.version_check.outputs.release_type == 'standard' && steps.version_check.outputs.dry-run == 'true' }}
+        if: ${{ steps.version_check.outputs.release_type == 'standard' &&
+                steps.version_check.outputs.dry-run == 'true' &&
+                steps.version_check.outputs.finalize-only != 'true' }}
         run: |
           echo "[DRY-RUN MODE] Running pub publish dry-run"
           flutter pub get
           flutter pub publish --dry-run
 
       - name: Publish to pub.dev (real)
-        if: ${{ steps.version_check.outputs.release_type == 'standard' && steps.version_check.outputs.dry-run == 'false' }}
+        if: ${{ steps.version_check.outputs.release_type == 'standard' &&
+                steps.version_check.outputs.dry-run == 'false' &&
+                steps.version_check.outputs.finalize-only != 'true' }}
         id: pub_publish
         uses: k-paxian/dart-package-publisher@master
         with:
@@ -263,7 +298,9 @@ jobs:
           skipTests: true
 
       - name: Fail if pub publish did not report success
-        if: ${{ steps.version_check.outputs.release_type == 'standard' && steps.version_check.outputs.dry-run == 'false' }}
+        if: ${{ steps.version_check.outputs.release_type == 'standard' &&
+                steps.version_check.outputs.dry-run == 'false' &&
+                steps.version_check.outputs.finalize-only != 'true' }}
         run: |
           set -eo pipefail
 
@@ -273,6 +310,23 @@ jobs:
             exit 1
           fi
 
+      - name: Verify existing pub.dev release (finalize-only)
+        if: ${{ steps.version_check.outputs.finalize-only == 'true' }}
+        run: |
+          set -eo pipefail
+
+          PACKAGE_NAME="$(awk '/^name:/ { print $2; exit }' pubspec.yaml)"
+          RELEASE_VERSION="${{ steps.version_check.outputs.version }}"
+
+          if ! curl --fail --silent --show-error "https://pub.dev/api/packages/${PACKAGE_NAME}" \
+            | jq -e --arg version "$RELEASE_VERSION" \
+                'any(.versions[]; .version == $version)' >/dev/null; then
+            echo "pub.dev does not contain ${PACKAGE_NAME} version ${RELEASE_VERSION}." >&2
+            exit 1
+          fi
+
+          echo "Verified ${PACKAGE_NAME} ${RELEASE_VERSION} already exists on pub.dev."
+
       - name: Finalize release artifacts
         if: ${{ steps.version_check.outputs.dry-run == 'false' }}
         run: |
@@ -281,20 +335,54 @@ jobs:
           RELEASE_TYPE="${{ steps.version_check.outputs.release_type }}"
           RELEASE_VERSION="${{ steps.version_check.outputs.version }}"
           TARGET_BRANCH="${{ steps.target_branch.outputs.branch }}"
+          FINALIZE_ONLY="${{ steps.version_check.outputs.finalize-only }}"
           RELEASE_NOTES_FILE="$(mktemp)"
 
-          git push origin "HEAD:${TARGET_BRANCH}"
-          git tag -a "$RELEASE_VERSION" -m "Release $RELEASE_VERSION"
-          git push origin "refs/tags/$RELEASE_VERSION"
+          if [ "$FINALIZE_ONLY" = "true" ]; then
+            echo "Skipping target branch push in finalize-only mode"
+          else
+            git push origin "HEAD:${TARGET_BRANCH}"
+          fi
+
+          EXPECTED_COMMIT="$(git rev-parse HEAD)"
+          set +e
+          TAG_LOOKUP_OUTPUT="$(git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_VERSION" 2>&1)"
+          TAG_LOOKUP_STATUS=$?
+          set -e
+
+          case "$TAG_LOOKUP_STATUS" in
+            0)
+              git fetch --force origin "refs/tags/$RELEASE_VERSION:refs/tags/$RELEASE_VERSION"
+              TAG_COMMIT="$(git rev-list -n 1 "$RELEASE_VERSION")"
+              if [ "$TAG_COMMIT" != "$EXPECTED_COMMIT" ]; then
+                echo "Existing tag $RELEASE_VERSION points to $TAG_COMMIT; expected $EXPECTED_COMMIT." >&2
+                exit 1
+              fi
+              echo "Tag $RELEASE_VERSION already exists at the expected commit"
+              ;;
+            2)
+              git tag -a "$RELEASE_VERSION" -m "Release $RELEASE_VERSION"
+              git push origin "refs/tags/$RELEASE_VERSION"
+              ;;
+            *)
+              echo "$TAG_LOOKUP_OUTPUT" >&2
+              echo "Unable to query remote tag $RELEASE_VERSION." >&2
+              exit "$TAG_LOOKUP_STATUS"
+              ;;
+          esac
 
           if [ "$RELEASE_TYPE" = "standard" ]; then
-            python3 -c 'import re, sys; from pathlib import Path; version = sys.argv[1]; output = Path(sys.argv[2]); text = Path("CHANGELOG.md").read_text(); pattern = re.compile(rf"(^## .*{re.escape(version)}.*?(?=^## |\\Z))", re.MULTILINE | re.DOTALL); match = pattern.search(text); (_ for _ in ()).throw(SystemExit(f"Unable to find release notes for {version} in CHANGELOG.md")) if not match else output.write_text(match.group(1).strip() + "\n")' \
-              "$RELEASE_VERSION" "$RELEASE_NOTES_FILE"
+            if gh release view "$RELEASE_VERSION" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+              echo "GitHub release $RELEASE_VERSION already exists"
+            else
+              python3 -c 'import re, sys; from pathlib import Path; version = sys.argv[1]; output = Path(sys.argv[2]); text = Path("CHANGELOG.md").read_text(); pattern = re.compile(rf"(^## .*{re.escape(version)}.*?(?=^## |\\Z))", re.MULTILINE | re.DOTALL); match = pattern.search(text); (_ for _ in ()).throw(SystemExit(f"Unable to find release notes for {version} in CHANGELOG.md")) if not match else output.write_text(match.group(1).strip() + "\n")' \
+                "$RELEASE_VERSION" "$RELEASE_NOTES_FILE"
 
-            gh release create "$RELEASE_VERSION" \
-              --repo "${{ github.repository }}" \
-              --title "Release $RELEASE_VERSION" \
-              --notes-file "$RELEASE_NOTES_FILE"
+              gh release create "$RELEASE_VERSION" \
+                --repo "${{ github.repository }}" \
+                --title "Release $RELEASE_VERSION" \
+                --notes-file "$RELEASE_NOTES_FILE"
+            fi
           else
             echo "Skipping GitHub release for special release"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,149 @@
 # Changelog
 
+## [1.6.4](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/1.6.3...1.6.4) (2026-08-05)
+
+### Bug Fixes
+
+* **android:** remove v1 embedding registration ([#240](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/issues/240)) ([bb4d835](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/bb4d835de51b0a645a2a56be9c6c13477b85f040))
+
+## [1.6.3](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/1.6.2...1.6.3) (2025-08-26)
+
+## [1.6.2](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/1.6.0...1.6.2) (2025-07-22)
+
+## [1.6.0](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/v1.5.9...1.6.0) (2025-04-22)
+
+### Bug Fixes
+
+* ios crashes ([#168](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/issues/168)) ([edc900f](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/edc900f4c54925904d6f816eb13afbe31ac2c039)), closes [#167](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/issues/167)
+
+## [1.5.9](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/v1.5.8...v1.5.9) (2023-11-23)
+
+### Bug Fixes
+
+* some function not call result ([8b75257](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/8b75257ec075dc4bb9fa155618cbe62de91395e7))
+
+## [1.5.8](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/v1.5.7...v1.5.8) (2023-08-07)
+
+### Bug Fixes
+
+* callManager not working on iOS ([5cd710c](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/5cd710c281319c9b211e9d099537e166129fb4c1))
+* getChannelMemberCount ([29140eb](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/29140eb260acb729b0c913d5c436c2ca910cbb1e))
+
+## [1.5.7](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/v1.5.6...v1.5.7) (2023-07-17)
+
+### Bug Fixes
+
+* ios crash while close app ([a25010e](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/a25010e2bab0a6bc90398505d95182a5a62d1847))
+
+## [1.5.6](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/v1.5.5...v1.5.6) (2023-06-28)
+
+### Bug Fixes
+
+* [android] Fix acceptRemoteInvitation return error code -1 ([#152](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/issues/152)) ([a8481ec](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/a8481ec4926134ca71edf8741cfd2457eddb3c14))
+
+## [1.5.5](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/v1.5.4...v1.5.5) (2023-06-09)
+
+### Bug Fixes
+
+* `onMemberCountUpdated` issue on iOS ([9d425f8](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/9d425f8d8446a61c84439023eaa214bc64513bd0))
+* `setLogFileSize` throw ([4570c3d](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/4570c3df11fd1add9d0d370492173c0f5fd2c2fb))
+* fromJson case ([c6b1cc5](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/c6b1cc57d2c5a57048e9d741a3cf07ce6aede343))
+
+## [1.5.4](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/v1.5.3...v1.5.4) (2023-06-05)
+
+### Bug Fixes
+
+* login not working on iOS & close [#148](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/issues/148) ([#149](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/issues/149)) ([6dbc424](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/6dbc4240c2e280abe3b124797edefda001b73e47))
+
+## [1.5.3](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/v1.5.2...v1.5.3) (2023-06-05)
+
+### Features
+
+* Flutter - Specify AreaCode in RTM [#87](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/issues/87) close [#146](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/issues/146) ([#147](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/issues/147)) ([c86657d](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/c86657d46d756ef413d6deb3bbedad5cd0fe445b))
+
+### Bug Fixes
+
+* FlutterStandardTypedData & init with wrong appId ([3bba6a9](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/3bba6a9806b0a505da6a329dc77f8342dc066d44))
+
+## [1.5.2](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/v1.5.1...v1.5.2) (2023-06-05)
+
+### Bug Fixes
+
+* 1.5.1 crash [#145](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/issues/145) Unhandled Exception when calling onPeersOnlineStatusChanged  [#146](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/issues/146) ([df4bcec](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/df4bcec5e65e8ae434781c52d093a4499b6c5321))
+
+## [1.5.1](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/v1.5.0...v1.5.1) (2023-06-02)
+
+### Bug Fixes
+
+* some issues [close [#142](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/issues/142) [#141](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/issues/141)] ([#144](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/issues/144)) ([79af48b](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/79af48b1054ee4da37277a8e94e6953a7793c598))
+
+## [1.5.0](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/v1.1.1...v1.5.0) (2022-11-30)
+
+### Features
+
+* upgrade native to 1.5.x ([69738fc](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/69738fcd67324256bf2c5a67be0b4eb97a22d4aa))
+
+## [1.1.1](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/v1.1.0...v1.1.1) (2022-05-30)
+
+## [1.1.0](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/v1.0.1...v1.1.0) (2022-03-08)
+
+### Features
+
+* upgrade to 1.4.10 ([52ef541](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/52ef5414d8a4c1fedb897ffc12f87143a4b7ff42))
+
+## [1.0.1](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/v1.0.0...v1.0.1) (2021-09-27)
+
+### Bug Fixes
+
+* null-safety error [#96](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/issues/96) ([62ab0f4](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/62ab0f45feafc4d6b0bee9d588f90f996956e80b))
+* pub get error on flutter 2.5 [#98](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/issues/98) ([5beb5f7](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/5beb5f7e23684785ec28eaca38aeb1b6e0131f9f))
+
+## [1.0.0](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/v1.0.0-rc.1...v1.0.0) (2021-08-25)
+
+### Features
+
+* upgrade to native 1.4.+ ([39dda38](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/39dda380a23b94b077e3bd19b2c830b6bd816501))
+
+### Bug Fixes
+
+* Removed unnecessary blank in `README.md` ([0e64bc3](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/0e64bc352952ca0fb04f062352462bb4375251a9))
+
+## [1.0.0-rc.0](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/0.9.14...1.0.0-rc.0) (2021-04-21)
+
+## [1.0.0-rc.1](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/1.0.0-rc.0...v1.0.0-rc.1) (2021-05-18)
+
+### Bug Fixes
+
+* **fix:** default bool value ([c68af85](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/c68af85295e3a1f971b506fae9640a383c2a52fb))
+
+## [1.0.0-rc.0](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/0.9.14...1.0.0-rc.0) (2021-04-21)
+
+### Bug Fixes
+
+* **modified the parameter value method:** the objectForKey API replaces the ternary operator ([9bc138b](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/commit/9bc138b335ff7dcaef5817a271f610e6bdcdd026))
+
+## [0.9.14](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/0.9.13...0.9.14) (2020-10-01)
+
+## [0.9.13](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/0.9.12...0.9.13) (2020-09-30)
+
+## [0.9.12](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/0.9.11...0.9.12) (2020-06-22)
+
+## [0.9.10](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/0.9.9...0.9.10) (2020-03-09)
+
+## [0.9.9](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/0.9.8...0.9.9) (2020-01-07)
+
+## [0.9.7](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/0.9.6...0.9.7) (2019-09-17)
+
+## [0.9.6](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/0.9.5...0.9.6) (2019-08-20)
+
+## [0.9.5](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/0.9.4...0.9.5) (2019-07-26)
+
+## [0.9.4](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/0.9.3...0.9.4) (2019-07-23)
+
+## [0.9.3](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/0.9.2...0.9.3) (2019-05-24)
+
+## 0.9.2 (2019-05-17)
+
 ## [1.6.3](https://github.com/AgoraIO-Extensions/Agora-Flutter-RTM-SDK/compare/1.6.2...1.6.3) (2025-08-26)
 
 ### Chore

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: agora_rtm
 description: >-
       Flutter wrapper around the Agora Real Time Message SDKs for Android and
       iOS.
-version: 1.6.3
+version: 1.6.4
 homepage: https://www.agora.io
 repository: https://github.com/AgoraIO/Flutter-RTM
 environment:


### PR DESCRIPTION
## Summary

- add a finalize-only workflow mode that skips release preparation and pub.dev publishing
- verify the exact published pub.dev version and safely create or reuse the release tag and GitHub Release
- sync CHANGELOG.md and pubspec.yaml with the published 1.6.4 package

## Validation

- actionlint v1.7.12 on .github/workflows/release.yml
- YAML parse and finalize-only behavior assertions
- pub.dev 1.6.4 archive SHA256 and release-file comparison
- tag absent, idempotent rerun, and mismatched-tag scenarios
- git diff --check